### PR TITLE
Hide unmatched branches during search

### DIFF
--- a/simpleTree.js
+++ b/simpleTree.js
@@ -455,6 +455,12 @@ $.fn.simpleTree = function(options, data) {
         ) {
             _self.hideNode(node);
         }
+        if(!node.searchInfo.matches 
+            && !node.searchInfo.anyChildMatches
+            && node.expanded
+        ) {
+            _self.toggleSubtree(node);
+        }
         _renderNodeLabelText(node);
         node.children.forEach(child => _setSearchVisibility(child));
         if(node.children.length > 0 && node.domToggle) {


### PR DESCRIPTION
As search continues, hide sections of the tree with no matching children.
e.g. staring to type "top" might match several parts of the tree, so they are opened.
Then the user continues to type "topology". This no longer matches some nodes, but currently those branches remain open. In a large tree, this can be distracting.
(This behaviour could be an option defined in _options)